### PR TITLE
Fix paste editing functionality and table interaction issues

### DIFF
--- a/src/app/(dashboard)/_components/pastes-content-wrapper.tsx
+++ b/src/app/(dashboard)/_components/pastes-content-wrapper.tsx
@@ -95,6 +95,10 @@ export function PastesContentWrapper({ pastes }: PastesContentWrapperProps) {
       content: paste.content,
       language: paste.language,
       visibility: paste.visibility,
+      burnAfterRead: paste.burnAfterRead,
+      burnAfterReadViews: paste.burnAfterReadViews,
+      expiresAt: paste.expiresAt,
+      hasPassword: paste.hasPassword,
       tags: paste.tags?.map(tag => ({ name: tag.name })) || [],
     });
   };

--- a/src/app/(landing)/_components/public-pastes-table.tsx
+++ b/src/app/(landing)/_components/public-pastes-table.tsx
@@ -85,7 +85,7 @@ export function PublicPastesTable({ pastes }: PublicPastesTableProps) {
         <TableHeader>
           <TableRow className="hover:bg-transparent">
             <TableHead className="w-10">Author</TableHead>
-            <TableHead>Title</TableHead>
+            <TableHead className="min-w-0 max-w-xs">Title</TableHead>
             <TableHead className="hidden sm:table-cell">Language</TableHead>
             <TableHead className="hidden md:table-cell">Views</TableHead>
             <TableHead className="hidden lg:table-cell">Created</TableHead>
@@ -111,21 +111,22 @@ export function PublicPastesTable({ pastes }: PublicPastesTableProps) {
                   </Avatar>
                 )}
               </TableCell>
-              <TableCell className="py-4">
+              <TableCell className="py-4 min-w-0 max-w-xs">
                 <div className="flex flex-col gap-1 min-w-0">
                   <Link
                     href={`/p/${paste.slug}`}
-                    className="font-medium text-sm hover:text-primary transition-colors line-clamp-1"
+                    className="font-medium text-sm hover:text-primary transition-colors block truncate"
+                    title={paste.title || `Paste ${paste.slug}`}
                   >
                     {paste.title || `Paste ${paste.slug}`}
                   </Link>
                   {paste.user && (
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-xs text-muted-foreground truncate" title={paste.user.name}>
                       by {paste.user.name}
                     </p>
                   )}
                   {paste.description && (
-                    <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5">
+                    <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5" title={paste.description}>
                       {paste.description}
                     </p>
                   )}

--- a/src/app/actions/paste.ts
+++ b/src/app/actions/paste.ts
@@ -27,16 +27,19 @@ import {
   deletePasteSchema,
   checkUrlAvailabilitySchema,
   updatePasteSettingsSchema,
+  updatePasteSchema,
   type CreatePasteResult,
   type GetPasteResult,
   type DeletePasteResult,
   type CheckUrlAvailabilityResult,
   type UpdatePasteSettingsResult,
+  type UpdatePasteResult,
   type CreatePasteInput,
   type GetPasteInput,
   type DeletePasteInput,
   type CheckUrlAvailabilityInput,
   type UpdatePasteSettingsInput,
+  type UpdatePasteInput,
 } from "@/types/paste";
 import bcrypt from "bcryptjs";
 
@@ -915,6 +918,189 @@ export async function checkUrlAvailability(input: CheckUrlAvailabilityInput): Pr
     return {
       available: false,
       error: error instanceof Error ? error.message : "Failed to check URL availability",
+    };
+  }
+}
+
+export async function updatePaste(input: UpdatePasteInput): Promise<UpdatePasteResult> {
+  try {
+    // Validate input
+    const validatedInput = updatePasteSchema.parse(input);
+    
+    // Get current user
+    const user = await getCurrentUser();
+    if (!user) {
+      return {
+        success: false,
+        error: "Authentication required",
+      };
+    }
+
+    // Check rate limiting
+    const rateLimitResult = await checkRateLimit(user.id, "update-paste");
+    if (!rateLimitResult.success) {
+      return {
+        success: false,
+        error: `Rate limit exceeded. Try again in a few minutes.`,
+      };
+    }
+
+    // Check character limits
+    const charLimit = CHAR_LIMIT_AUTHENTICATED;
+    if (validatedInput.content.length > charLimit) {
+      return {
+        success: false,
+        error: `Content exceeds ${charLimit} character limit`,
+      };
+    }
+
+    // Find the paste and verify ownership
+    const existingPaste = await db
+      .select({
+        id: paste.id,
+        slug: paste.slug,
+        userId: paste.userId,
+        password: paste.password,
+      })
+      .from(paste)
+      .where(
+        and(
+          eq(paste.id, validatedInput.id),
+          eq(paste.isDeleted, false)
+        )
+      )
+      .limit(1);
+
+    if (existingPaste.length === 0) {
+      return {
+        success: false,
+        error: "Paste not found",
+      };
+    }
+
+    const targetPaste = existingPaste[0];
+
+    // Verify ownership
+    if (targetPaste.userId !== user.id) {
+      return {
+        success: false,
+        error: "You can only edit your own pastes",
+      };
+    }
+
+    // Handle password
+    let hashedPassword: string | null = targetPaste.password;
+    if (validatedInput.removePassword) {
+      hashedPassword = null;
+    } else if (validatedInput.password) {
+      hashedPassword = await bcrypt.hash(validatedInput.password, 10);
+    }
+
+    // Handle expiry
+    let expiresAt: Date | null = null;
+    if (validatedInput.expiresIn && validatedInput.expiresIn !== "remove") {
+      expiresAt = calculateExpiryDate(validatedInput.expiresIn, true);
+    }
+
+    // Update the paste
+    const [updatedPaste] = await db
+      .update(paste)
+      .set({
+        title: validatedInput.title || null,
+        description: validatedInput.description || null,
+        content: validatedInput.content,
+        language: validatedInput.language,
+        visibility: validatedInput.visibility,
+        password: hashedPassword,
+        burnAfterRead: validatedInput.burnAfterRead,
+        burnAfterReadViews: validatedInput.burnAfterRead ? validatedInput.burnAfterReadViews || 1 : null,
+        expiresAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(paste.id, validatedInput.id))
+      .returning({
+        id: paste.id,
+        slug: paste.slug,
+      });
+
+    if (!updatedPaste) {
+      return {
+        success: false,
+        error: "Failed to update paste",
+      };
+    }
+
+    // Handle tags
+    if (validatedInput.tags) {
+      // Remove existing tags
+      await db.delete(pasteTag).where(eq(pasteTag.pasteId, validatedInput.id));
+
+      // Add new tags
+      if (validatedInput.tags.length > 0) {
+        for (const tagName of validatedInput.tags) {
+          // Create a slug from the tag name
+          const tagSlug = tagName.toLowerCase().replace(/[^a-z0-9-_]/g, '-').replace(/-+/g, '-').trim();
+          const tagId = nanoid();
+
+          // Insert tag if it doesn't exist
+          const existingTag = await db
+            .select({ id: tag.id })
+            .from(tag)
+            .where(eq(tag.slug, tagSlug))
+            .limit(1);
+
+          let tagIdToUse: string;
+          
+          if (existingTag.length === 0) {
+            // Create new tag
+            const newTag = await db
+              .insert(tag)
+              .values({
+                id: tagId,
+                name: tagName,
+                slug: tagSlug,
+                color: `#${Math.floor(Math.random()*16777215).toString(16)}`, // Random color
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              })
+              .returning({ id: tag.id });
+            tagIdToUse = newTag[0].id;
+          } else {
+            tagIdToUse = existingTag[0].id;
+          }
+
+          // Link tag to paste
+          await db.insert(pasteTag).values({
+            pasteId: validatedInput.id,
+            tagId: tagIdToUse,
+          });
+        }
+      }
+    }
+
+    // Clear cache for this paste
+    await deleteFromCache(generateCacheKey(CACHE_KEYS.PASTE, updatedPaste.slug));
+    
+    // Clear user pastes cache
+    await deleteFromCache(generateCacheKey(CACHE_KEYS.USER_PASTES, user.id));
+
+    // Revalidate relevant paths
+    revalidatePath('/dashboard');
+    revalidatePath(`/p/${updatedPaste.slug}`);
+
+    return {
+      success: true,
+      paste: {
+        id: updatedPaste.id,
+        slug: updatedPaste.slug,
+        url: `${APP_URL}/p/${updatedPaste.slug}`,
+      },
+    };
+  } catch (error) {
+    console.error("Update paste error:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to update paste",
     };
   }
 }

--- a/src/components/shared/paste/paste-modal-provider.tsx
+++ b/src/components/shared/paste/paste-modal-provider.tsx
@@ -10,6 +10,10 @@ interface EditingPaste {
   content: string;
   language: string;
   visibility: string;
+  burnAfterRead: boolean;
+  burnAfterReadViews: number | null;
+  expiresAt: Date | null;
+  hasPassword: boolean;
   tags?: Array<{ name: string }>;
 }
 

--- a/src/components/shared/paste/paste-preview-modal.tsx
+++ b/src/components/shared/paste/paste-preview-modal.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { PasteViewer } from "./paste-viewer";
+import { 
+  Copy, 
+  ExternalLink, 
+  Edit, 
+  Trash2, 
+  Eye, 
+  Calendar,
+  Shield,
+  Clock
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { toast } from "sonner";
+
+interface PastePreviewModalProps {
+  paste: {
+    id: string;
+    slug: string;
+    title: string | null;
+    description: string | null;
+    content: string;
+    language: string;
+    visibility: "public" | "private" | "unlisted";
+    views: number;
+    createdAt: Date;
+    expiresAt: Date | null;
+    burnAfterRead: boolean;
+    hasPassword: boolean;
+    user: {
+      id: string;
+      name: string;
+      image: string | null;
+    } | null;
+    tags: Array<{
+      id: string;
+      name: string;
+      color: string;
+    }>;
+  } | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onEdit?: () => void;
+  onDelete?: (pasteId: string) => void;
+}
+
+export function PastePreviewModal({ 
+  paste, 
+  open, 
+  onOpenChange, 
+  onEdit, 
+  onDelete 
+}: PastePreviewModalProps) {
+  const [copied, setCopied] = useState(false);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  useEffect(() => {
+    if (copied) {
+      const timer = setTimeout(() => setCopied(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [copied]);
+
+  if (!paste) return null;
+
+  const handleCopyUrl = async () => {
+    try {
+      const pasteUrl = `${window.location.origin}/p/${paste.slug}`;
+      await navigator.clipboard.writeText(pasteUrl);
+      setCopied(true);
+      toast.success("URL copied to clipboard!");
+    } catch {
+      toast.error("Failed to copy URL");
+    }
+  };
+
+  const handleViewPaste = () => {
+    window.open(`/p/${paste.slug}`, '_blank');
+  };
+
+  const getVisibilityBadge = () => {
+    switch (paste.visibility) {
+      case "private":
+        return <Badge variant="secondary" className="text-xs"><Shield className="h-3 w-3 mr-1" />Private</Badge>;
+      case "unlisted":
+        return <Badge variant="outline" className="text-xs"><Eye className="h-3 w-3 mr-1" />Unlisted</Badge>;
+      default:
+        return <Badge variant="default" className="text-xs"><Eye className="h-3 w-3 mr-1" />Public</Badge>;
+    }
+  };
+
+  const isExpired = paste.expiresAt && new Date() > paste.expiresAt;
+
+  const HeaderContent = () => (
+    <div className="space-y-4">
+      {/* Title and Actions */}
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <h2 className="text-xl font-semibold leading-tight truncate">
+            {paste.title || `Paste ${paste.slug}`}
+          </h2>
+          {paste.description && (
+            <p className="text-sm text-muted-foreground mt-2 line-clamp-3">
+              {paste.description}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleCopyUrl}
+            className="text-xs h-8"
+          >
+            <Copy className="h-3 w-3 mr-1" />
+            {copied ? "Copied!" : "Copy URL"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleViewPaste}
+            className="text-xs h-8"
+          >
+            <ExternalLink className="h-3 w-3 mr-1" />
+            View
+          </Button>
+          {onEdit && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onEdit}
+              className="text-xs h-8"
+            >
+              <Edit className="h-3 w-3 mr-1" />
+              Edit
+            </Button>
+          )}
+          {onDelete && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onDelete(paste.id)}
+              className="text-xs h-8 text-destructive hover:text-destructive"
+            >
+              <Trash2 className="h-3 w-3 mr-1" />
+              Delete
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Metadata */}
+      <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+        {paste.user && (
+          <div className="flex items-center gap-2">
+            <Avatar className="h-6 w-6">
+              <AvatarImage src={paste.user.image || undefined} alt={paste.user.name} />
+              <AvatarFallback className="text-xs">
+                {paste.user.name.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <span className="truncate">{paste.user.name}</span>
+          </div>
+        )}
+        <div className="flex items-center gap-1">
+          <Calendar className="h-3 w-3 flex-shrink-0" />
+          <span className="truncate">{formatDistanceToNow(paste.createdAt, { addSuffix: true })}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Eye className="h-3 w-3 flex-shrink-0" />
+          <span>{paste.views} views</span>
+        </div>
+        {paste.expiresAt && (
+          <div className="flex items-center gap-1">
+            <Clock className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate">Expires {formatDistanceToNow(paste.expiresAt, { addSuffix: true })}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Badges */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="text-xs">
+          {paste.language}
+        </Badge>
+        {getVisibilityBadge()}
+        {paste.hasPassword && (
+          <Badge variant="secondary" className="text-xs">
+            <Shield className="h-3 w-3 mr-1" />
+            Password Protected
+          </Badge>
+        )}
+        {paste.burnAfterRead && (
+          <Badge variant="destructive" className="text-xs">
+            Burn After Read
+          </Badge>
+        )}
+        {isExpired && (
+          <Badge variant="destructive" className="text-xs">
+            Expired
+          </Badge>
+        )}
+        {paste.tags.map((tag) => (
+          <Badge
+            key={tag.id}
+            variant="outline"
+            className="text-xs"
+            style={{ borderColor: tag.color, color: tag.color }}
+          >
+            {tag.name}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+
+  const ContentArea = () => (
+    <div className="flex-1 min-h-0">
+      <div className="h-full w-full overflow-auto rounded-lg border">
+        <PasteViewer
+          content={paste.content}
+          language={paste.language}
+          showHeader={false}
+          className="min-h-full"
+        />
+      </div>
+    </div>
+  );
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent 
+          className="max-w-[90vw] w-full max-h-[85vh] sm:max-w-2xl lg:max-w-4xl xl:max-w-5xl p-0 flex flex-col"
+          showCloseButton={true}
+        >
+          {/* Header - Fixed with padding for close button */}
+          <div className="flex-shrink-0 p-6 pr-12 border-b bg-background">
+            <HeaderContent />
+          </div>
+          
+          {/* Content - Scrollable */}
+          <div className="flex-1 min-h-0 p-6">
+            <ContentArea />
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="h-[95vh] flex flex-col">
+        {/* Header - Fixed */}
+        <div className="flex-shrink-0 p-4 border-b bg-background">
+          <HeaderContent />
+        </div>
+        
+        {/* Content - Scrollable */}
+        <div className="flex-1 min-h-0 p-4">
+          <ContentArea />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    
+    // Set initial value
+    setMatches(media.matches);
+    
+    // Create listener
+    const listener = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+    
+    // Add listener
+    if (media.addEventListener) {
+      media.addEventListener("change", listener);
+    } else {
+      // Fallback for older browsers
+      media.addListener(listener);
+    }
+    
+    // Cleanup
+    return () => {
+      if (media.removeEventListener) {
+        media.removeEventListener("change", listener);
+      } else {
+        // Fallback for older browsers
+        media.removeListener(listener);
+      }
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/src/types/paste.ts
+++ b/src/types/paste.ts
@@ -46,11 +46,31 @@ export const updatePasteSettingsSchema = z.object({
   expiresIn: z.enum(["1h", "1d", "7d", "30d", "never", "remove"]).optional(),
 });
 
+export const updatePasteSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().max(100).optional(),
+  description: z.string().max(500).optional(),
+  content: z.string().min(1, "Content is required"),
+  language: z.enum(SUPPORTED_LANGUAGES).default("plain"),
+  visibility: z.enum([
+    PASTE_VISIBILITY.PUBLIC,
+    PASTE_VISIBILITY.UNLISTED,
+    PASTE_VISIBILITY.PRIVATE,
+  ]).default(PASTE_VISIBILITY.PUBLIC),
+  password: z.string().optional(),
+  removePassword: z.boolean().default(false),
+  burnAfterRead: z.boolean().default(false),
+  burnAfterReadViews: z.number().min(1).max(100).optional(),
+  tags: z.array(z.string().min(1).max(20)).max(5).optional(),
+  expiresIn: z.enum(["1h", "1d", "7d", "30d", "never", "remove"]).optional(),
+});
+
 export type CreatePasteInput = z.infer<typeof createPasteSchema>;
 export type GetPasteInput = z.infer<typeof getPasteSchema>;
 export type DeletePasteInput = z.infer<typeof deletePasteSchema>;
 export type CheckUrlAvailabilityInput = z.infer<typeof checkUrlAvailabilitySchema>;
 export type UpdatePasteSettingsInput = z.infer<typeof updatePasteSettingsSchema>;
+export type UpdatePasteInput = z.infer<typeof updatePasteSchema>;
 
 export interface PasteResult {
   id: string;
@@ -106,5 +126,15 @@ export interface CheckUrlAvailabilityResult {
 
 export interface UpdatePasteSettingsResult {
   success: boolean;
+  error?: string;
+}
+
+export interface UpdatePasteResult {
+  success: boolean;
+  paste?: {
+    id: string;
+    slug: string;
+    url: string;
+  };
   error?: string;
 }


### PR DESCRIPTION
  - Fix SQL query error in updatePaste action tag handling by removing non-existent tag.userId reference
  - Fix form pre-population issues by unifying schema usage and improving useEffect dependencies
  - Fix action dropdown triggering row click modal by adding proper stopPropagation handlers
  - Add comprehensive form reset logic to populate all fields when editing (title, content, tags, expiry, etc.)
  - Update tag creation logic to match database schema (global tags without userId)
  - Ensure table reflects changes immediately after paste updates
  - Add proper TypeScript types and error handling throughout edit flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to edit existing pastes, including fields such as title, description, content, language, visibility, tags, password, burn-after-read settings, and expiration.
  - Introduced a detailed paste preview modal for viewing paste information with syntax highlighting and metadata.
  - Added responsive modal and drawer views for paste previews based on screen size.
  - Implemented a new hook for detecting media queries.

- **Improvements**
  - Enhanced public pastes table with better text truncation, tooltips for full text on hover, and improved accessibility.
  - Improved table interactions with clearer row and button behaviors, and more accessible UI elements.

- **Bug Fixes**
  - Fixed event propagation issues to prevent unintended modal openings when interacting with table elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->