### PR TITLE
fix: convert infinite scroll to client-side only implementation

### DIFF
--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -1,10 +1,6 @@
-// Force dynamic rendering for landing page
-export const dynamic = 'force-dynamic';
-
 import { WarpBackground } from "@/components/magicui/warp-background";
 import { HomeClient } from "@/features/landing/components/sections/home-client";
 import { PublicPasteCardsInfinite } from "@/features/landing/components/ui/public-paste-cards-infinite";
-import { getPublicPastesPaginated } from "@/features/paste/actions/paste.actions";
 import { Badge } from "@/shared/components/dupui/badge";
 import {
   Panel,
@@ -27,24 +23,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 
-export default async function Home() {
-  let recentPastesData;
-  try {
-    recentPastesData = await getPublicPastesPaginated(1, 8);
-  } catch (error) {
-    console.error('Failed to fetch public pastes for landing page:', error);
-    recentPastesData = { 
-      pastes: [], 
-      pagination: { 
-        page: 1, 
-        limit: 8, 
-        total: 0, 
-        totalPages: 0, 
-        hasMore: false 
-      } 
-    };
-  }
-  const recentPastes = recentPastesData.pastes;
+export default function Home() {
 
   return (
     <div className="max-w-4xl mx-auto px-4">
@@ -164,13 +143,7 @@ export default async function Home() {
           </PanelTitle>
         </PanelHeader>
         <PanelContent>
-          <PublicPasteCardsInfinite 
-            initialPastes={recentPastes.map(paste => ({
-              ...paste,
-              createdAt: paste.createdAt.toISOString()
-            }))} 
-            initialPagination={recentPastesData.pagination}
-          />
+          <PublicPasteCardsInfinite />
         </PanelContent>
       </Panel>
       <Pattern />

--- a/src/features/landing/components/ui/public-paste-cards-infinite.tsx
+++ b/src/features/landing/components/ui/public-paste-cards-infinite.tsx
@@ -110,25 +110,12 @@ export function PublicPasteCardsInfinite({
     }
   }, [pagination.limit]);
 
-  // Auto-load on scroll (optional - can be enabled)
+  // Load initial data on component mount
   useEffect(() => {
-    // Uncomment the code below to enable auto-scroll loading
-    /*
-    const handleScroll = () => {
-      if (
-        window.innerHeight + document.documentElement.scrollTop >= 
-        document.documentElement.offsetHeight - 1000 &&
-        pagination.hasMore &&
-        !isLoading
-      ) {
-        loadMorePastes();
-      }
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-    */
-  }, [loadMorePastes, pagination.hasMore, isLoading]);
+    if (pastes.length === 0) {
+      refreshPastes();
+    }
+  }, []);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
- Remove server-side data fetching from homepage
- Make PublicPasteCardsInfinite component self-contained
- Load initial data on component mount instead of server-side
- Allow homepage to be statically generated again

This resolves deployment server errors caused by forcing dynamic rendering on the homepage for infinite scroll functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the landing page to load recent pastes using client-side logic, removing all server-side data fetching and error handling.
  - Simplified the public pastes display component by removing infinite scroll on scroll events; now, pastes are loaded only once when the component mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->